### PR TITLE
Commands with clickpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * PostgreSQL 9.4+ with default contrib extensions
 * Python 2.7.10+
 * [pyresttest](https://github.com/svanoort/pyresttest)
+* [click](http://click.pocoo.org/)
 
 The scripts assume that you have a PostgreSQL running in your local environment
 and that you have a database superuser with the same name as the user running the script.
@@ -14,13 +15,19 @@ You also need to be able to connect with any arbitrary PostgreSQL user without a
 
 If you need to use a password to connect try setting up a [pgpass](http://www.postgresql.org/docs/current/static/libpq-pgpass.html) file.
 
+## Installation
+
+```
+pip install -r requirements.txt
+```
+
 ## Running tests
 
 If everything is installed and configured properly you should be able to run the entire suite
 using the command:
 
 ```
-./run_tests.sh
+python api_spec.py run_tests
 ```
 
 You can also pass one parameter with a different database name to use for testing.
@@ -34,7 +41,7 @@ After modifying the development database you should run this script
 and run the tests to check if everything is still working.
 
 ```
-database/recreate_schema.sh database_name
+python api_spec.py recreate_schema --name=database_name
 ```
 
 ## Adding tests
@@ -47,6 +54,6 @@ testing the endpoint **foo**, the test file will be **test/foo.yml**.
 To bootstrap a basic get test against the foo endpoint use the command:
 
 ```
-./generate_test.sh foo
+python api_spec.py generate_test --name=foo
 ```
 

--- a/api_spec.py
+++ b/api_spec.py
@@ -1,0 +1,28 @@
+import subprocess
+import click
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+def run_tests():
+    subprocess.call(['./run_tests.sh'])
+
+
+@cli.command()
+@click.option('--name', help='database name')
+def recreate_schema(name):
+    subprocess.call(['./database/recreate_schema.sh', name])
+
+
+@cli.command()
+@click.option('--name', help='spec name')
+def generate_test(name):
+    subprocess.call(['./generate_test.sh', name])
+
+
+if __name__ == '__main__':
+    cli()

--- a/api_spec.py
+++ b/api_spec.py
@@ -8,8 +8,9 @@ def cli():
 
 
 @cli.command()
-def run_tests():
-    subprocess.call(['./run_tests.sh'])
+@click.argument('name', default='api_test')
+def run_tests(name):
+    subprocess.call(['./run_tests.sh', name])
 
 
 @cli.command()

--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,9 @@ machine:
 
 dependencies:
   pre:
-      - pip install pyresttest
+      - pip install -r requirements.txt
 
 test:
   override:
-    - ./run_tests.sh api_test
+    - python api_spec.py run_tests api_test
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyresttest==1.6.0
+click==5.1


### PR DESCRIPTION
I created this submodule to organize all commands for use just one single file, stills use shell scripts anyway.

Simple output usage to list all commands:

```
$ python api_spec.py
Usage: api_spec.py [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  generate_test
  recreate_schema
  run_tests
```

Another example to show a help for a single command:

```
$ python api_spec.py generate_test --help
Usage: api_spec.py generate_test [OPTIONS]

Options:
  --name TEXT  spec name
  --help       Show this message and exit.
```

To run tests:

```
$ python api_spec.py run_tests
```
