### PR TITLE
Change pyresttest version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,5 +8,5 @@ dependencies:
 
 test:
   override:
-    - ./run_tests.sh
+    - ./api_spec.py run_tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyresttest==1.6.0
+-e git+https://github.com/svanoort/pyresttest.git#egg=pyresttest
 click==5.1


### PR DESCRIPTION
- Update pyresttest to last development version (PATCH fixed and py3 compatibility). The maintainer will release a new version next month.
- CircleCI now use api_spec.py to run tests.
